### PR TITLE
feat: change the behavior of the typescript `consistent-type-imports` rule

### DIFF
--- a/.changeset/cold-socks-stare.md
+++ b/.changeset/cold-socks-stare.md
@@ -1,0 +1,5 @@
+---
+'@detra-lab/eslint-config': minor
+---
+
+Change the behaviour of the `@typescript-eslint/no-redeclare` rule to favour `inline-type-imports` over `separate-type-imports`.

--- a/.changeset/cold-socks-stare.md
+++ b/.changeset/cold-socks-stare.md
@@ -2,4 +2,4 @@
 '@detra-lab/eslint-config': minor
 ---
 
-Change the behaviour of the `@typescript-eslint/no-redeclare` rule to favour `inline-type-imports` over `separate-type-imports`.
+Changed the behaviour of the `@typescript-eslint/no-redeclare` rule to favour `inline-type-imports` over `separate-type-imports`.

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -168,7 +168,10 @@ const TYPESCRIPT_RULES = {
   '@typescript-eslint/no-use-before-define': STATUS.None,
 
   '@typescript-eslint/consistent-type-exports': STATUS.Warn,
-  '@typescript-eslint/consistent-type-imports': STATUS.Warn,
+  '@typescript-eslint/consistent-type-imports': [
+    STATUS.Warn,
+    { fixStyle: 'inline-type-imports' }
+  ],
   '@typescript-eslint/explicit-function-return-type': [
     STATUS.Warn,
     { allowExpressions: true }


### PR DESCRIPTION
I have changed the behaviour of the `@typescript-eslint/no-redeclare` rule to favour `inline-type-imports` over `separate-type-imports`.

[Here](https://typescript-eslint.io/rules/consistent-type-imports/#fixstyle) are more details.