### PR TITLE
feat: remove the react jsx-runtime plugin

### DIFF
--- a/.changeset/selfish-seas-try.md
+++ b/.changeset/selfish-seas-try.md
@@ -1,0 +1,5 @@
+---
+'@detra-lab/eslint-config': minor
+---
+
+Remove the `react/jsx-runtime` plugin and all related rules such as `jsx-uses-react` and `react-in-jsx`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 2. Create a `.eslintrc.json` file in the root of your project and extend it with our configuration:
 
-   ```jsonc
+   ```json
    {
      "root": true,
      "extends": "@detra-lab/eslint-config"
@@ -45,7 +45,8 @@
 
     <details>
       <summary><strong>JavaScript + React</strong></summary>
-      ```json
+
+      ```jsonc
       {
         "root": true,
         "extends": [
@@ -58,6 +59,7 @@
 
     <details>
       <summary><strong>TypeScript</strong></summary>
+
       ```jsonc
       {
         "root": true,
@@ -77,6 +79,7 @@
 
     <details>
       <summary><strong>TypeScript + React</strong></summary>
+
       ```jsonc
       {
         "root": true,

--- a/src/react.ts
+++ b/src/react.ts
@@ -48,7 +48,6 @@ const REACT_RULES = {
 
 export = {
   extends: [
-    'plugin:react/jsx-runtime',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended'


### PR DESCRIPTION
Remove the `react/jsx-runtime` plugin and all related rules such as `jsx-uses-react` and `react-in-jsx`.